### PR TITLE
feat: Add twitter follower count

### DIFF
--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -194,3 +194,26 @@ jobs:
               tags:
                 - "project:haystack-core-integrations"
                 - "type:health"
+
+  twitter-metrics:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        username:
+          - Haystack_AI
+          - llama_index
+          - LangChainAI
+
+    env:
+      DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Get Twitter follower count
+        working-directory: collector
+        run: hatch run collector twitter --username ${{ matrix.username }} followers

--- a/collector/pyproject.toml
+++ b/collector/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "pypistats",
   "datadog",
   "gql[all]",
+  "selenium",
 ]
 
 [project.urls]

--- a/collector/src/collector/cli/__init__.py
+++ b/collector/src/collector/cli/__init__.py
@@ -6,6 +6,7 @@ import click
 from collector.__about__ import __version__
 from .github import github_cli
 from .pypi import pypi_cli
+from .twitter import twitter_scraper
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
@@ -16,3 +17,4 @@ def collector():
 
 collector.add_command(github_cli)
 collector.add_command(pypi_cli)
+collector.add_command(twitter_scraper)

--- a/collector/src/collector/cli/twitter/__init__.py
+++ b/collector/src/collector/cli/twitter/__init__.py
@@ -1,0 +1,65 @@
+import os
+import re
+import time
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+
+import click
+from datadog import initialize
+from datadog import api as dd
+
+
+@click.group("twitter")
+@click.option('--username', default="Haystack_AI")
+@click.option('--dd-api-key', default="")
+@click.option('--dd-api-host', default="https://api.datadoghq.eu")
+@click.option('--dry-run', default=False, is_flag=True)
+@click.pass_context
+def twitter_scraper(ctx, username, dd_api_key, dd_api_host, dry_run):
+    ctx.ensure_object(dict)
+    ctx.obj['DRY_RUN'] = dry_run
+    ctx.obj['DEFAULT_TAGS'] = ["type:health", "source:twitter", f"username:{username}"]
+
+    options = ChromeOptions()
+    options.headless = True
+    target_url = f"https://twitter.com/{username}"
+    driver = webdriver.Chrome(options=options)
+    driver.get(target_url)
+    time.sleep(10)
+    response = driver.page_source
+    driver.close()
+
+    try:
+        follower_count_element_idx = response.find('<a href="/Haystack_AI/verified_followers"')
+        ctx.obj["FOLLOWERS"] = find_next_match(response, follower_count_element_idx, r'>\d{3,}<')[1:-1]
+    except:
+        ctx.obj["FOLLOWERS"] = 0
+
+    dd_api_key = dd_api_key or os.environ.get("DD_API_KEY")
+    if dd_api_key:
+        initialize(api_key=dd_api_key, api_host=dd_api_host)
+
+
+@twitter_scraper.command()
+@click.pass_context
+def followers(ctx):
+    followers = ctx.obj.get('FOLLOWERS')
+    if not ctx.obj.get('DRY_RUN'):
+        dd.Metric.send(
+            metric="haystack.twitter.followers", points=[(time.time(), int(followers))], tags=ctx.obj.get('DEFAULT_TAGS')
+        )
+
+    click.echo(followers)
+
+def find_next_match(text, start_index, pattern):
+    # Use re.search() to find the next match
+    match = re.search(pattern, text[start_index:])
+
+    if match:
+        # Adjust the start position by adding the start_index
+        start_pos = match.start() + start_index
+        end_pos = match.end() + start_index
+        return text[start_pos:end_pos]
+    else:
+        raise RuntimeError("No match found")


### PR DESCRIPTION
This PR adds scraping the twitter follower count from Haystack, llama index and langchain. It uses selenium. 
A dry run worked with: `hatch run collector twitter --username Haystack_AI --dry-run followers`

Alternatives I considered are using the Twitter API (costly) or scraping just with `requests` (doesn't work because of dynamically loaded content). Another alternative is not using Twitter follower count but measuring social media mentions through one of our Slack channels. I think, Twitter follower count is better.