### PR TITLE
fix: get_views_traffic, get_clones_traffic return PyGithub objects instead of dict

### DIFF
--- a/collector/src/collector/cli/github/__init__.py
+++ b/collector/src/collector/cli/github/__init__.py
@@ -81,10 +81,10 @@ def clones(ctx):
     if not ctx.obj.get('DRY_RUN'):
         dd.Metric.send(
             metric="haystack.github.clones",
-            points=[(time.time(), int(stats["count"]))],
+            points=[(time.time(), int(stats.count))],
             tags=ctx.obj.get('DEFAULT_TAGS'),
         )
-    click.echo(stats["count"])
+    click.echo(stats.count)
 
 
 @github_cli.command()
@@ -95,10 +95,10 @@ def views(ctx):
     if not ctx.obj.get('DRY_RUN'):
         dd.Metric.send(
             metric="haystack.github.views",
-            points=[(time.time(), int(stats["count"]))],
+            points=[(time.time(), int(stats.count))],
             tags=ctx.obj.get('DEFAULT_TAGS'),
         )
-    click.echo(stats["count"])
+    click.echo(stats.count)
 
 
 @github_cli.command()


### PR DESCRIPTION
The most recent release of pygithub includes a [breaking change](https://pygithub.readthedocs.io/en/stable/changes.html#breaking-changes) that let broke parts of our [metrics workflow](https://github.com/deepset-ai/haystack-metrics/actions/runs/13360042275/job/37308215447). 

View and clones traffic information returned by Repository.get_views_traffic and Repository.get_clones_traffic now return proper PyGithub objects, instead of a dict, with all information that used to be provided by the dict.

To adjust to that breaking change, this PR changes for get_views_traffic and get_clones_traffic how we access the stats
so that we now use `int(stats.count)` instead of `int(stats["count"])`