### PR TITLE
fix: use `overall` api for daily pypi stats

### DIFF
--- a/collector/src/collector/cli/pypi/__init__.py
+++ b/collector/src/collector/cli/pypi/__init__.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 import json
 
 import click
@@ -13,5 +14,14 @@ def pypi_cli():
 @click.argument('package_name')
 @click.argument('timeframe', default="last_day")
 def downloads(package_name, timeframe):
-    stats = json.loads(pypistats.recent(package_name, format="json"))
-    click.echo(stats["data"][timeframe])
+    if timeframe == "last_day":
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        stats = json.loads(
+            pypistats.overall(
+                package_name, format="json", start_date=yesterday, end_date=yesterday, mirrors=False
+            )
+        )
+        click.echo(stats["data"][0]["downloads"])
+    else:
+        stats = json.loads(pypistats.recent(package_name, format="json"))
+        click.echo(stats["data"][timeframe])

--- a/collector/src/collector/cli/pypi/__init__.py
+++ b/collector/src/collector/cli/pypi/__init__.py
@@ -14,7 +14,7 @@ def pypi_cli():
 @click.argument('package_name')
 @click.argument('timeframe', default="last_day")
 def downloads(package_name, timeframe):
-    if timeframe == "last_day":
+    if timeframe == "last_day":  # Use pypistats.overall because .recent daily numbers don't sum up to monthly total
         yesterday = (date.today() - timedelta(days=1)).isoformat()
         stats = json.loads(
             pypistats.overall(


### PR DESCRIPTION
We’re using  
`pypistats.recent(package_name, format="json")`

which returns 
`{"last_day": 7468, "last_month": 363537, "last_week": 84648}`
These numbers are without mirrors (see
https://github.com/crflynn/pypistats.org/blob/70a10f994173b4b9e8905fb3494dd5d0d5bd1bbb/pypistats/tasks/pypi.py#L200 )

These are also the numbers one can see on: https://pypistats.org/packages/haystack-ai

However, these daily numbers are not adding up to the monthly numbers. Therefore I suggest using a different way to fetch daily numbers using `pypistats.overall`. We're explicitly setting `mirrors=False` so that the counting method used for daily numbers matches the method used for monthly numbers.

```python
yesterday = (date.today() - timedelta(days=1)).isoformat()
stats = json.loads(
    pypistats.overall(
        package_name, format="json", start_date=yesterday, end_date=yesterday, mirrors=False
    )
)
print(stats["data"][0]["downloads"])
```