### PR TITLE
fix: rate limit pypistats calls to 30/min

### DIFF
--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -68,6 +68,9 @@ jobs:
 
   haystack-pypi-metrics:
     runs-on: ubuntu-latest
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: false
     strategy:
       matrix:
         package:
@@ -76,6 +79,7 @@ jobs:
           - llama-index
           - langchain
           - hayhooks
+      max-parallel: 2
 
     steps:
       - name: Checkout
@@ -88,8 +92,12 @@ jobs:
         id: pypi-downloads
         working-directory: collector
         run: |
+          # Add delay between API calls
+          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
+          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
+          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -142,9 +150,13 @@ jobs:
   integrations-pypi-metrics:
     needs: generate-integrations-matrix
     runs-on: ubuntu-latest
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: false
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
+      max-parallel: 2
 
     steps:
       - name: Checkout
@@ -157,8 +169,12 @@ jobs:
         id: pypi-downloads
         working-directory: collector
         run: |
+          # Add delay between API calls
+          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
+          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
+          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -196,6 +212,9 @@ jobs:
 
   non-haystack-core-integrations-pypi-metrics:
     runs-on: ubuntu-latest
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: false
     strategy:
       matrix:
         package:
@@ -219,6 +238,7 @@ jobs:
           - takeoff-haystack
           - vllm-haystack
           - voyage-embedders-haystack
+      max-parallel: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -230,6 +250,8 @@ jobs:
         id: pypi-downloads
         working-directory: collector
         run: |
+          # Add delay between API calls
+          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -93,11 +93,11 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
+          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
+          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -170,11 +170,11 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
+          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 3  # Wait 3 seconds between calls to stay under 30 requests/minute
+          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -251,7 +251,7 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 5 + 2))  # Random delay between 2-7 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
pypistats has a rate limit of 5 per second, and 30 per minute: https://github.com/crflynn/pypistats.org/blob/master/pypistats/run.py#L23
Currently, we run into errors because we hit that limit. 

Changes in this PR:

- 4 seconds of delay between calls 
- Maximum of 2 jobs running in parallel
- Random initial delay of 4-6 seconds to lower the chance that jobs start at exactly the same time

With at least 4 seconds between calls of a job, we do at most 15 calls per job in a minute.
With max 2 parallel jobs this means we won't exceed 30 calls per minute. And the time it takes to do each api call is a safety margin.