### PR TITLE
fix: increase sleep between pypistats calls

### DIFF
--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -68,9 +68,6 @@ jobs:
 
   haystack-pypi-metrics:
     runs-on: ubuntu-latest
-    concurrency:
-      group: pypi-metrics
-      cancel-in-progress: false
     strategy:
       matrix:
         package:
@@ -79,7 +76,7 @@ jobs:
           - llama-index
           - langchain
           - hayhooks
-      max-parallel: 2
+      max-parallel: 1
 
     steps:
       - name: Checkout
@@ -93,11 +90,11 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 10))  # Random delay between 10-12 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
+          sleep 10  # Wait 10 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
+          sleep 10  # Wait 10 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -150,9 +147,6 @@ jobs:
   integrations-pypi-metrics:
     needs: generate-integrations-matrix
     runs-on: ubuntu-latest
-    concurrency:
-      group: pypi-metrics
-      cancel-in-progress: false
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
@@ -170,11 +164,11 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 10))  # Random delay between 10-12 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
+          sleep 10  # Wait 10 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 4  # Wait 4 seconds between calls to stay under 30 requests/minute
+          sleep 10  # Wait 10 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -212,9 +206,6 @@ jobs:
 
   non-haystack-core-integrations-pypi-metrics:
     runs-on: ubuntu-latest
-    concurrency:
-      group: pypi-metrics
-      cancel-in-progress: false
     strategy:
       matrix:
         package:
@@ -251,7 +242,7 @@ jobs:
         working-directory: collector
         run: |
           # Add delay between API calls
-          sleep $((RANDOM % 3 + 4))  # Random delay between 4-6 seconds to spread out initial requests
+          sleep $((RANDOM % 3 + 10))  # Random delay between 10-12 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Using `concurrency` feature resulted in cancelled jobs
sleep time between pypistats calls is increased to account for up to 5 jobs happening in parallel (rate limit is 5 per second, and 30 per minute.)