### PR TITLE
Collect metrics at 2am and 2pm UTC

### DIFF
--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -3,7 +3,7 @@ name: Collect Haystack metrics
 on:
   workflow_dispatch:
   schedule:
-    # Run twice a day, at midnight and noon
+    # Run twice a day, at 2am and 2pm UTC. New data becomes available ~1am https://pypistats.org/faqs
     - cron: "0 2,14 * * *"
   push:
     branches: [main]

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run twice a day, at midnight and noon
-    - cron: "0 0,12 * * *"
+    - cron: "0 2,14 * * *"
   push:
     branches: [main]
     paths: [".github/workflows/github_metrics.yml"]


### PR DESCRIPTION
We're using PyPIStats, which in turn relies on PyPI that provides download records as a publicly available dataset on Google's BigQuery. 

Every day, the data update begins at 01:00:00 UTC and should take about 10 minutes according to https://pypistats.org/faqs

Instead of collecting data at 0 and 12 UTC, we should collect data at 2 and 14 UTC so that we get new data as soon as it becomes available. 

Note that we're collecting twice a day to prevent missing any data in case one of the two workflows fail. They are expected to collect the exact same data if none of them fails.