### PR TITLE
Reduce PyPI failures

### DIFF
--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -154,7 +154,7 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
-      max-parallel: 2
+      max-parallel: 1
       fail-fast: false
 
     steps:
@@ -235,7 +235,7 @@ jobs:
           - takeoff-haystack
           - vllm-haystack
           - voyage-embedders-haystack
-      max-parallel: 2
+      max-parallel: 1
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -75,7 +75,6 @@ jobs:
     # avoid rate limiting
     concurrency:
       group: pypi-metrics
-      cancel-in-progress: true
     strategy:
       matrix:
         package:
@@ -160,7 +159,6 @@ jobs:
     # avoid rate limiting
     concurrency:
       group: pypi-metrics
-      cancel-in-progress: true
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
@@ -225,7 +223,6 @@ jobs:
     # avoid rate limiting
     concurrency:
       group: pypi-metrics
-      cancel-in-progress: true
     strategy:
       matrix:
         package:

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -71,10 +71,6 @@ jobs:
 
   haystack-pypi-metrics:
     runs-on: ubuntu-latest
-    
-    # avoid rate limiting
-    concurrency:
-      group: pypi-metrics
     strategy:
       matrix:
         package:
@@ -153,12 +149,8 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   integrations-pypi-metrics:
-    needs: generate-integrations-matrix
+    needs: [generate-integrations-matrix, haystack-pypi-metrics]
     runs-on: ubuntu-latest
-    
-    # avoid rate limiting
-    concurrency:
-      group: pypi-metrics
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
@@ -219,10 +211,7 @@ jobs:
 
   non-haystack-core-integrations-pypi-metrics:
     runs-on: ubuntu-latest
-    
-    # avoid rate limiting
-    concurrency:
-      group: pypi-metrics
+    needs: [integrations-pypi-metrics]
     strategy:
       matrix:
         package:

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -71,6 +71,11 @@ jobs:
 
   haystack-pypi-metrics:
     runs-on: ubuntu-latest
+    
+    # avoid rate limiting
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: true
     strategy:
       matrix:
         package:
@@ -151,6 +156,11 @@ jobs:
   integrations-pypi-metrics:
     needs: generate-integrations-matrix
     runs-on: ubuntu-latest
+    
+    # avoid rate limiting
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: true
     strategy:
       matrix:
         package: ${{ fromJson(needs.generate-integrations-matrix.outputs.matrix).packages }}
@@ -211,6 +221,11 @@ jobs:
 
   non-haystack-core-integrations-pypi-metrics:
     runs-on: ubuntu-latest
+    
+    # avoid rate limiting
+    concurrency:
+      group: pypi-metrics
+      cancel-in-progress: true
     strategy:
       matrix:
         package:

--- a/.github/workflows/github_metrics.yml
+++ b/.github/workflows/github_metrics.yml
@@ -96,9 +96,9 @@ jobs:
           # Add delay between API calls
           sleep $((RANDOM % 10 + 10))  # Random delay between 10-20 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 15  # Wait 15 seconds between calls to stay under 30 requests/minute
+          sleep 25  # Wait 25 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 15  # Wait 15 seconds between calls to stay under 30 requests/minute
+          sleep 25  # Wait 25 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -150,6 +150,7 @@ jobs:
 
   integrations-pypi-metrics:
     needs: [generate-integrations-matrix, haystack-pypi-metrics]
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -171,9 +172,9 @@ jobs:
           # Add delay between API calls
           sleep $((RANDOM % 10 + 10))  # Random delay between 10-20 seconds to spread out initial requests
           last_month=$(hatch run collector pypi downloads ${{ matrix.package }} last_month)
-          sleep 15  # Wait 15 seconds between calls to stay under 30 requests/minute
+          sleep 25  # Wait 25 seconds between calls to stay under 30 requests/minute
           last_week=$(hatch run collector pypi downloads ${{ matrix.package }} last_week)
-          sleep 15  # Wait 15 seconds between calls to stay under 30 requests/minute
+          sleep 25  # Wait 25 seconds between calls to stay under 30 requests/minute
           last_day=$(hatch run collector pypi downloads ${{ matrix.package }} last_day)
           echo "last_month=$last_month" >> $GITHUB_OUTPUT
           echo "last_week=$last_week" >> $GITHUB_OUTPUT
@@ -212,6 +213,7 @@ jobs:
   non-haystack-core-integrations-pypi-metrics:
     runs-on: ubuntu-latest
     needs: [integrations-pypi-metrics]
+    if: always()
     strategy:
       matrix:
         package:


### PR DESCRIPTION
Despite the recent efforts, this workflow is still failing, especially on PyPI requests.

As a temporary mitigation, I am
- setting `max-parallel: 1`
- using `needs` on PyPI jobs
- increasing sleep time

This makes the workflow slower, but reduces failures.

Looking forward, future improvements should focus on redesigning how metrics are collected.